### PR TITLE
feat: add image to notes

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -94,8 +94,8 @@ Project background_fetch = project(':react-native-background-fetch')
         applicationId 'com.lumi.mobile'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 19
-        versionName "1.7"
+        versionCode 1
+        versionName "1.0.0"
     }
     signingConfigs {
         debug {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -94,8 +94,9 @@ Project background_fetch = project(':react-native-background-fetch')
         applicationId 'com.lumi.mobile'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0.0"
+        // Bump above the last published versionCode (19)
+        versionCode 20
+        versionName "1.8.0"
     }
     signingConfigs {
         debug {

--- a/app/components/inputContainer.tsx
+++ b/app/components/inputContainer.tsx
@@ -15,6 +15,7 @@ export default function InputContainer({
   onlyRecording,
   placeholder,
   containerStyle,
+  onAddImagePress,
 }: {
   userResponse: string;
   setUserResponse: (text: string) => void;
@@ -25,6 +26,7 @@ export default function InputContainer({
   onlyRecording?: boolean;
   placeholder?: string;
   containerStyle?: StyleProp<ViewStyle>;
+  onAddImagePress?: () => void;
 }) {
   const { colors, createThemedStyles } = useTheme();
   const processedResultsRef = React.useRef<Set<string>>(new Set());
@@ -122,6 +124,15 @@ export default function InputContainer({
         multiline={true}
         numberOfLines={4}
       />
+      
+      <TouchableOpacity
+        style={{ paddingHorizontal: 8 }}
+        onPress={() => {
+          onAddImagePress?.();
+        }}
+      >
+        <Ionicons name="image-outline" size={22} color={colors.text} />
+      </TouchableOpacity>
 
       <TouchableOpacity
         style={[styles.micButton, { marginLeft: 8 }]}

--- a/app/store/memoryStore.ts
+++ b/app/store/memoryStore.ts
@@ -5,6 +5,7 @@ import type { Memory as DatabaseMemory } from '@/utils/database';
 export interface Memory extends Omit<DatabaseMemory, 'id'> {
   id: number;
   type: 'memory';
+  images?: string[]; 
 }
 
 interface MemoryState {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "expo-dev-client": "~5.0.20",
     "expo-font": "~13.0.4",
     "expo-haptics": "~14.0.1",
+    "expo-image-picker": "~16.0.6",
     "expo-linking": "~7.0.5",
     "expo-router": "~4.0.20",
     "expo-speech-recognition": "^2.0.0",

--- a/utils/tools.ts
+++ b/utils/tools.ts
@@ -433,10 +433,12 @@ const clientTools = {
     title,
     content,
     tags,
+    images,
   }: {
     title: string;
     content: string;
     tags: string[];
+    images?: string[];
   }) => {
     try {
       const memory = await db.addMemory({
@@ -444,6 +446,7 @@ const clientTools = {
         content,
         date: new Date().toISOString(),
         tags,
+        images: images || [],
       });
       return { success: true, id: memory.id };
     } catch (error) {


### PR DESCRIPTION
## Description
user can pick images to notes

<img width="386" height="862" alt="Screenshot from 2025-10-10 15-17-39" src="https://github.com/user-attachments/assets/feb630c8-8ccd-44b6-9884-7666e7591416" />

<img width="386" height="862" alt="Screenshot from 2025-10-10 15-18-06" src="https://github.com/user-attachments/assets/db6b8e41-78a1-4fb1-987e-734805308a1a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attach images to notes from your device via a new image button in the input bar.
  * Preview selected images in a horizontal strip, remove any before saving, and have images persisted with the note.

* **Chores**
  * Android app version bumped to 1.8.0.
  * Added image picking and local file support to enable attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->